### PR TITLE
set window.location properly

### DIFF
--- a/www/js/meteor-rider.js
+++ b/www/js/meteor-rider.js
@@ -57,7 +57,7 @@ var MeteorRider = {
         
         // set the window.location object correctly so iron-router 
         // and other packages that depend on window.location work correctly
-        window.history.pushState({}, "", "/");
+        window.history.replaceState({}, "", meteorUrl);
         
         // replace the document with the new document/data
         document.open();


### PR DESCRIPTION
In order to play nice with iron-router, and anything else that depends on window.location, we need to update the window.location property. I tried a few methods, and updating it with the history api seems to be the best option. I have not tested this in android browsers, but it works well in iOS 5 and up.
