### PR TITLE
pass currentPath to persist through hot code reload

### DIFF
--- a/www/js/meteor-rider.js
+++ b/www/js/meteor-rider.js
@@ -30,7 +30,7 @@
 
 //define('MeteorRider', ['jquery'], function($) {
 var MeteorRider = {
-  init: function() {
+  init: function(currentPath) {
     var meteorUrl = __MeteorRiderConfig__.meteorUrl;
     if (! (meteorUrl.length > 0)) {
       console.error('MeteorRider: error: unable to determine config.meteorUrl');
@@ -55,6 +55,8 @@ var MeteorRider = {
           console.log(meteorUrl);
         console.log(data);
         
+        // set 'currentPath' to empty string if not passed
+        currentPath = typeof currentPath === 'string' ? currentPath : '';
         // set the window.location object correctly so iron-router 
         // and other packages that depend on window.location work correctly
         window.history.replaceState({}, "", meteorUrl + currentPath);

--- a/www/js/phonegapapp.js
+++ b/www/js/phonegapapp.js
@@ -50,7 +50,8 @@ phonegapapp = {
   },
   // Setup MeteorRider
   meteorRider: function(currentPath) {
-    currentPath = typeof currentPath !== 'undefined' ? currentPath : '';
-    MeteorRider.init();
+    // set 'currentPath' to empty string if not passed
+    currentPath = typeof currentPath === 'string' ? currentPath : '';
+    MeteorRider.init(currentPath);
   }
 };


### PR DESCRIPTION
I was having trouble with the current route not persisting through a hot code reload.  I came up with a quick solution that seems to fix the problem.  Is this the right way to go about it?

In `phonegapapp.js`, accept a `currentPath` parameter and pass to `MeteorRider.init()`:

``` javascript
phonegapapp = {
  ...
  meteorRider: function(currentPath) {
    currentPath = typeof currentPath !== 'undefined' ? currentPath : '';
    MeteorRider.init(currentPath);
  }
}
```

Receive `currentPath` within `meteor-rider.js` and use in `window.history.replaceState()`:

``` javascript
var MeteorRider = {
  init: function(currentPath) {
    ...
    // trigger request
    $.ajax({
      ...
      success: function( data, textStatus, jqXHR ) {
        ...
        window.history.replaceState({}, "", meteorUrl + currentPath);
      }
    });
  }
}
```

And then, in the `Meteor.startup()` function, simply pass the current route (I'm using Iron-Router):

``` javascript
if(typeof phonegapapp !== 'undefined'){
  Meteor._reload.onMigrate('phonegapapp', function(){
    phonegapapp.meteorRider(Router.current().path);
    return [false];
  });
};
```
