### PR TITLE
fixed reloading on hot pushes

### DIFF
--- a/meteor/startup.js
+++ b/meteor/startup.js
@@ -1,24 +1,26 @@
 if (Meteor.isClient) {
   Meteor.startup(function () {
-    if (typeof phonegapapp === 'undefined') {
+    // verify if we are within a cordova wrapper
+    if (typeof cordova === 'undefined') {
       return;
     }
-    // we have a phonegap app
+    // we have a cordova app
     //   attempt to setup a callback handler for hot reloads
-    
-    if (typeof Reload._onMigrate === 'function') {
+
+    if (typeof Reload !== 'undefined' && typeof Reload._onMigrate === 'function') {
       // this is the newer method, internal?
-      Reload._onMigrate('phonegapapp', function () {
-        phonegapapp.meteorRider();
+      Reload._onMigrate('cordovaapp', function () {
+        MeteorRider.init();
         return [false];
       });
       return;
     }
-    
+
     if (typeof Meteor._reload.onMigrate === 'function') {
       // this is the older method, deprecated?
-      Meteor._reload.onMigrate('phonegapapp', function () {
-        phonegapapp.meteorRider();
+      // it does not seem to be deprecated in meteor 0.8.2
+      Meteor._reload.onMigrate('cordovaapp', function () {
+        MeteorRider.init();
         return [false];
       });
       return;


### PR DESCRIPTION
Removed dependencies from phonegapapp variable. We test if we are in a cordova wrapper checking if cordova variable is defined.

Called MeteorRider.init instead of phonegapapp.meteorRider() wrapper. We do not need to pass meteorUrl parameter because it is setup in MeteorRider internal properties the first time the init method is called.

Fixed minor bug when Reload is not defined.
