### PR TITLE
Fix for silent failure when loading in PhoneGap

### DIFF
--- a/www/js/meteor-rider.js
+++ b/www/js/meteor-rider.js
@@ -307,19 +307,14 @@ var MeteorRider = {
       console.log("MeteorRider replaceHistoryState SKIPPED no window.history");
       return;
     }
-    var url = this.config.meteorUrl + this.config.currentPath;
     if (typeof window.history.replaceState === 'function') {
-      window.history.replaceState({}, "", url);
+      window.history.replaceState({}, "", this.config.currentPath);
       return;
     }
     if (typeof window.history.pushState === 'function') {
-      window.history.pushState({}, "", url);
+      window.history.pushState({}, "", this.config.currentPath);
       return;
     }
-    // TODO: should we do window.history.add() or something?
-    console.log("MeteorRider replaceHistoryState SKIPPED no window.history. replaceState or pushState");
-    console.log("typeof window.history.replaceState " + typeof window.history.replaceState);
-    console.log("typeof window.history.pushState " + typeof window.history.pushState);
   },
 
   /**


### PR DESCRIPTION
As discussed in https://github.com/zeroasterisk/MeteorRider/issues/7#issuecomment-50597807

This fixes the path passed to `history.replaceState` and `history.pushState`.
